### PR TITLE
Fix turn off transition

### DIFF
--- a/custom_components/rgbct/rgbct_light_output.h
+++ b/custom_components/rgbct/rgbct_light_output.h
@@ -113,22 +113,12 @@ public:
 
   void write_state(light::LightState *state) override
   {
-    // Handle turn off
-    if (!state->current_values.is_on()) {
-      this->red_->set_level(0.0);
-      this->green_->set_level(0.0);
-      this->blue_->set_level(0.0);
-      this->warm_white_->set_level(0.0);
-      this->cold_white_->set_level(0.0);
-      return;
-    }
-
     float cwhite = 0.0, wwhite = 0.0;
     float red = state->current_values.get_red();
     float green = state->current_values.get_green();
     float blue = state->current_values.get_blue();
     float colorTemp = state->current_values.get_color_temperature();
-    const float brightness = state->current_values.get_brightness();
+    const float brightness = state->current_values.get_brightness() * state->current_values.get_state();
     const bool white_changed = this->last_color_temp_ != colorTemp;
     const bool color_changed = this->last_rgb_ != red + green + blue;
 


### PR DESCRIPTION
Correctly sets the brightness so transitions work.

As an alternative may want to use [this](https://esphome.io/api/light__color__values_8h_source.html#l00200) as it provides the actual values with brightness multiplied out. Not sure if this would provide too much abstraction for what needs to be done here though. This provides color temp as a fraction of cw/ww and rgb with brightness/state multiplied out. 