### PR TITLE
Rename rgbct -> rgbcct

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,8 +18,8 @@ Create a real Philips HUE Lightstrip look-a-like with ESPHome and RGB+CT lightst
 
 ```
 light:
-  - platform: rgbct
-    name: "${device_name}: RGBCT Light"
+  - platform: rgbcct
+    name: "${device_name}: RGBCCT Light"
     red: pwm_r
     green: pwm_g
     blue: pwm_b

--- a/components/rgbct/light.py
+++ b/components/rgbct/light.py
@@ -12,8 +12,8 @@ from esphome.const import (
     CONF_WARM_WHITE_COLOR_TEMPERATURE,
 )
 
-rgbct_ns = cg.esphome_ns.namespace("rgbct")
-RGBCTLightOutput = rgbct_ns.class_("RGBCTLightOutput", light.LightOutput)
+rgbcct_ns = cg.esphome_ns.namespace("rgbcct")
+RGBCCTLightOutput = rgbcct_ns.class_("RGBCCTLightOutput", light.LightOutput)
 
 CONF_MAX_WARM_COLOR_TEMPERATURE = "max_warm_color_temperature"
 CONF_MAX_COLD_COLOR_TEMPERATURE = "max_cold_color_temperature"
@@ -22,7 +22,7 @@ CONF_MAX_COMBINED_WHITE_LEVEL = "max_combined_white_level"
 
 CONFIG_SCHEMA = light.RGB_LIGHT_SCHEMA.extend(
     {
-        cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(RGBCTLightOutput),
+        cv.GenerateID(CONF_OUTPUT_ID): cv.declare_id(RGBCCTLightOutput),
         cv.Required(CONF_RED): cv.use_id(output.FloatOutput),
         cv.Required(CONF_GREEN): cv.use_id(output.FloatOutput),
         cv.Required(CONF_BLUE): cv.use_id(output.FloatOutput),

--- a/components/rgbct/rgbct_light_output.h
+++ b/components/rgbct/rgbct_light_output.h
@@ -5,9 +5,9 @@
 #include "esphome/components/light/light_output.h"
 
 namespace esphome {
-namespace rgbct {
+namespace rgbcct {
 
-class RGBCTLightOutput : public light::LightOutput {
+class RGBCCTLightOutput : public light::LightOutput {
  public:
   void set_red(output::FloatOutput *red) { this->red_ = red; }
   void set_green(output::FloatOutput *green) { this->green_ = green; }
@@ -159,5 +159,5 @@ class RGBCTLightOutput : public light::LightOutput {
   float max_combined_white_level_;
 };
 
-}  // namespace rgbct
+}  // namespace rgbcct
 }  // namespace esphome


### PR DESCRIPTION
ESPHome now has a component named rgbct. Rename to avoid conflicting with the internal esphome component.